### PR TITLE
Refactoring "messanger" -> "messenger"

### DIFF
--- a/the_tale/game/actions/tests/test_battle.py
+++ b/the_tale/game/actions/tests/test_battle.py
@@ -337,7 +337,7 @@ class TryCompanionBlockTests(TestsBase):
         self.assertFalse(actor_1.has_companion)
         self.assertFalse(actor_2.has_companion)
 
-        self.assertFalse(battle.try_companion_block(attacker=actor_2, defender=actor_1, messanger=self.hero))
+        self.assertFalse(battle.try_companion_block(attacker=actor_2, defender=actor_1, messenger=self.hero))
 
 
     @mock.patch('the_tale.game.balance.formulas.companions_defend_in_battle_probability', mock.Mock(return_value=1.0))
@@ -350,7 +350,7 @@ class TryCompanionBlockTests(TestsBase):
         self.assertTrue(actor_1.has_companion)
         self.assertFalse(actor_2.has_companion)
 
-        self.assertFalse(battle.try_companion_block(attacker=actor_1, defender=actor_2, messanger=self.hero))
+        self.assertFalse(battle.try_companion_block(attacker=actor_1, defender=actor_2, messenger=self.hero))
 
 
     @mock.patch('the_tale.game.balance.formulas.companions_defend_in_battle_probability', mock.Mock(return_value=0.0))
@@ -366,7 +366,7 @@ class TryCompanionBlockTests(TestsBase):
         with self.check_not_changed(self.hero.diary.__len__):
             with self.check_not_changed(self.hero.messages.__len__):
                 with self.check_not_changed(lambda: self.hero.companion.health):
-                    self.assertFalse(battle.try_companion_block(attacker=actor_2, defender=actor_1, messanger=self.hero))
+                    self.assertFalse(battle.try_companion_block(attacker=actor_2, defender=actor_1, messenger=self.hero))
 
 
     @mock.patch('the_tale.game.balance.formulas.companions_defend_in_battle_probability', mock.Mock(return_value=1.0))
@@ -383,7 +383,7 @@ class TryCompanionBlockTests(TestsBase):
         with self.check_not_changed(self.hero.diary.__len__):
             with self.check_delta(self.hero.messages.__len__, 1):
                 with self.check_not_changed(lambda: self.hero.companion.health):
-                    self.assertTrue(battle.try_companion_block(attacker=actor_2, defender=actor_1, messanger=self.hero))
+                    self.assertTrue(battle.try_companion_block(attacker=actor_2, defender=actor_1, messenger=self.hero))
 
         self.assertTrue(self.hero.messages.messages[-1].key.is_COMPANIONS_BLOCK)
 
@@ -401,7 +401,7 @@ class TryCompanionBlockTests(TestsBase):
         with self.check_not_changed(self.hero.diary.__len__):
             with self.check_delta(self.hero.messages.__len__, 1):
                 with self.check_delta(lambda: self.hero.companion.health, -c.COMPANIONS_DAMAGE_PER_WOUND):
-                    self.assertTrue(battle.try_companion_block(attacker=actor_2, defender=actor_1, messanger=self.hero))
+                    self.assertTrue(battle.try_companion_block(attacker=actor_2, defender=actor_1, messenger=self.hero))
 
         self.assertTrue(self.hero.messages.messages[-1].key.is_COMPANIONS_WOUND)
 
@@ -418,7 +418,7 @@ class TryCompanionBlockTests(TestsBase):
 
         with self.check_delta(self.hero.diary.__len__, 1):
             while self.hero.companion:
-                self.assertTrue(battle.try_companion_block(attacker=actor_2, defender=actor_1, messanger=self.hero))
+                self.assertTrue(battle.try_companion_block(attacker=actor_2, defender=actor_1, messenger=self.hero))
 
         self.assertEqual(self.hero.companion, None)
         self.assertFalse(actor_1.has_companion)
@@ -443,7 +443,7 @@ class TryCompanionBlockTests(TestsBase):
             self.check_delta(self.hero.diary.__len__, 2)):
 
             while self.hero.companion:
-                self.assertTrue(battle.try_companion_block(attacker=actor_2, defender=actor_1, messanger=self.hero))
+                self.assertTrue(battle.try_companion_block(attacker=actor_2, defender=actor_1, messenger=self.hero))
 
         self.assertEqual(self.hero.companion, None)
         self.assertFalse(actor_1.has_companion)
@@ -466,7 +466,7 @@ class TryCompanionStrikeTests(TestsBase):
         self.assertFalse(actor_1.has_companion)
         self.assertFalse(actor_2.has_companion)
 
-        self.assertFalse(battle.try_companion_strike(attacker=actor_1, defender=actor_2, messanger=self.hero))
+        self.assertFalse(battle.try_companion_strike(attacker=actor_1, defender=actor_2, messenger=self.hero))
 
 
     @mock.patch('the_tale.game.balance.constants.COMPANIONS_BATTLE_STRIKE_PROBABILITY', 0.0)
@@ -476,7 +476,7 @@ class TryCompanionStrikeTests(TestsBase):
         self.assertTrue(actor_1.has_companion)
         self.assertFalse(actor_2.has_companion)
 
-        self.assertFalse(battle.try_companion_strike(attacker=actor_1, defender=actor_2, messanger=self.hero))
+        self.assertFalse(battle.try_companion_strike(attacker=actor_1, defender=actor_2, messenger=self.hero))
 
 
     @mock.patch('the_tale.game.balance.constants.COMPANIONS_BATTLE_STRIKE_PROBABILITY', 1.0)
@@ -486,7 +486,7 @@ class TryCompanionStrikeTests(TestsBase):
         self.assertTrue(actor_1.has_companion)
         self.assertFalse(actor_2.has_companion)
 
-        self.assertFalse(battle.try_companion_strike(attacker=actor_1, defender=actor_2, messanger=self.hero))
+        self.assertFalse(battle.try_companion_strike(attacker=actor_1, defender=actor_2, messenger=self.hero))
 
 
     @mock.patch('the_tale.game.balance.constants.COMPANIONS_BATTLE_STRIKE_PROBABILITY', 1.0)
@@ -505,4 +505,4 @@ class TryCompanionStrikeTests(TestsBase):
         self.assertTrue(actor_1.has_companion)
         self.assertFalse(actor_2.has_companion)
 
-        self.assertTrue(battle.try_companion_strike(attacker=actor_1, defender=actor_2, messanger=self.hero))
+        self.assertTrue(battle.try_companion_strike(attacker=actor_1, defender=actor_2, messenger=self.hero))

--- a/the_tale/game/heroes/fake.py
+++ b/the_tale/game/heroes/fake.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-class FakeMessanger(object):
+class FakeMessenger(object):
 
     def __init__(self):
         self.messages = []

--- a/the_tale/game/heroes/habilities/battle.py
+++ b/the_tale/game/heroes/habilities/battle.py
@@ -25,15 +25,15 @@ class HIT(AbilityPrototype):
     @property
     def damage_modifier(self): return self.DAMAGE_MODIFIER[self.level-1]
 
-    def use(self, messanger, actor, enemy):
+    def use(self, messenger, actor, enemy):
         damage = actor.basic_damage*self.damage_modifier
         damage = actor.context.modify_outcoming_damage(damage)
         damage = enemy.context.modify_incoming_damage(damage)
         enemy.change_health(-damage.total)
-        messanger.add_message('hero_ability_hit', attacker=actor, defender=enemy, damage=damage.total)
+        messenger.add_message('hero_ability_hit', attacker=actor, defender=enemy, damage=damage.total)
 
-    def on_miss(self, messanger, actor, enemy):
-        messanger.add_message('hero_ability_hit_miss', attacker=actor, defender=enemy)
+    def on_miss(self, messenger, actor, enemy):
+        messenger.add_message('hero_ability_hit_miss', attacker=actor, defender=enemy)
 
 
 class STRONG_HIT(AbilityPrototype):
@@ -54,15 +54,15 @@ class STRONG_HIT(AbilityPrototype):
     @property
     def damage_modifier(self): return self.DAMAGE_MODIFIER[self.level-1]
 
-    def use(self, messanger, actor, enemy):
+    def use(self, messenger, actor, enemy):
         damage = actor.basic_damage * self.damage_modifier
         damage = actor.context.modify_outcoming_damage(damage)
         damage = enemy.context.modify_incoming_damage(damage)
         enemy.change_health(-damage.total)
-        messanger.add_message('hero_ability_strong_hit', attacker=actor, defender=enemy, damage=damage.total)
+        messenger.add_message('hero_ability_strong_hit', attacker=actor, defender=enemy, damage=damage.total)
 
-    def on_miss(self, messanger, actor, enemy):
-        messanger.add_message('hero_ability_strong_hit_miss', attacker=actor, defender=enemy)
+    def on_miss(self, messenger, actor, enemy):
+        messenger.add_message('hero_ability_strong_hit_miss', attacker=actor, defender=enemy)
 
 
 class MAGIC_MUSHROOM(AbilityPrototype):
@@ -85,9 +85,9 @@ class MAGIC_MUSHROOM(AbilityPrototype):
     @property
     def damage_factors(self): return self.DAMAGE_FACTORS[self.level-1]
 
-    def use(self, messanger, actor, enemy): # pylint: disable=W0613
+    def use(self, messenger, actor, enemy): # pylint: disable=W0613
         actor.context.use_ability_magic_mushroom(self.damage_factors)
-        messanger.add_message('hero_ability_magicmushroom', actor=actor)
+        messenger.add_message('hero_ability_magicmushroom', actor=actor)
 
 
 class SIDESTEP(AbilityPrototype):
@@ -110,12 +110,12 @@ class SIDESTEP(AbilityPrototype):
     @property
     def miss_probabilities(self): return self.MISS_PROBABILITIES[self.level-1]
 
-    def use(self, messanger, actor, enemy):
+    def use(self, messenger, actor, enemy):
         enemy.context.use_ability_sidestep(self.miss_probabilities)
-        messanger.add_message('hero_ability_sidestep', attacker=actor, defender=enemy)
+        messenger.add_message('hero_ability_sidestep', attacker=actor, defender=enemy)
 
-    def on_miss(self, messanger, actor, enemy):
-        messanger.add_message('hero_ability__miss', attacker=actor, defender=enemy)
+    def on_miss(self, messenger, actor, enemy):
+        messenger.add_message('hero_ability__miss', attacker=actor, defender=enemy)
 
 
 class RUN_UP_PUSH(AbilityPrototype):
@@ -144,16 +144,16 @@ class RUN_UP_PUSH(AbilityPrototype):
     @property
     def damage_modifier(self): return self.DAMAGE_MODIFIER[self.level-1]
 
-    def use(self, messanger, actor, enemy):
+    def use(self, messenger, actor, enemy):
         damage = actor.basic_damage * self.damage_modifier
         damage = actor.context.modify_outcoming_damage(damage)
         damage = enemy.context.modify_incoming_damage(damage)
         enemy.change_health(-damage.total)
         enemy.context.use_stun(int(round(random.uniform(*self.stun_length))))
-        messanger.add_message('hero_ability_runuppush', attacker=actor, defender=enemy, damage=damage.total)
+        messenger.add_message('hero_ability_runuppush', attacker=actor, defender=enemy, damage=damage.total)
 
-    def on_miss(self, messanger, actor, enemy):
-        messanger.add_message('hero_ability_runuppush_miss', attacker=actor, defender=enemy)
+    def on_miss(self, messenger, actor, enemy):
+        messenger.add_message('hero_ability_runuppush_miss', attacker=actor, defender=enemy)
 
 
 
@@ -175,10 +175,10 @@ class REGENERATION(AbilityPrototype):
 
     def can_be_used(self, actor): return actor.health < actor.max_health
 
-    def use(self, messanger, actor, enemy): # pylint: disable=W0613
+    def use(self, messenger, actor, enemy): # pylint: disable=W0613
         health_to_regen = f.mob_hp_to_lvl(actor.level) * self.restored_percent * (1 + random.uniform(-c.DAMAGE_DELTA, c.DAMAGE_DELTA))# !!!MOB HP, NOT HERO!!!
         applied_health = int(round(actor.change_health(health_to_regen)))
-        messanger.add_message('hero_ability_regeneration', actor=actor, health=applied_health)
+        messenger.add_message('hero_ability_regeneration', actor=actor, health=applied_health)
 
 
 class CRITICAL_HIT(AbilityPrototype):
@@ -260,16 +260,16 @@ class FIREBALL(AbilityPrototype):
     @property
     def periodic_damage_modifiers(self): return self.PERIODIC_DAMAGE_MODIFIERS[self.level-1]
 
-    def use(self, messanger, actor, enemy):
+    def use(self, messenger, actor, enemy):
         damage = actor.basic_damage * self.damage_modifier
         outcoming_damage = actor.context.modify_outcoming_damage(damage)
         damage = enemy.context.modify_incoming_damage(outcoming_damage)
         enemy.change_health(-damage.total)
         enemy.context.use_damage_queue_fire([outcoming_damage * modifier for modifier in self.periodic_damage_modifiers])
-        messanger.add_message('hero_ability_fireball', attacker=actor, defender=enemy, damage=damage.total)
+        messenger.add_message('hero_ability_fireball', attacker=actor, defender=enemy, damage=damage.total)
 
-    def on_miss(self, messanger, actor, enemy):
-        messanger.add_message('hero_ability_fireball_miss', attacker=actor, defender=enemy)
+    def on_miss(self, messenger, actor, enemy):
+        messenger.add_message('hero_ability_fireball_miss', attacker=actor, defender=enemy)
 
 
 class POISON_CLOUD(AbilityPrototype):
@@ -293,11 +293,11 @@ class POISON_CLOUD(AbilityPrototype):
     @property
     def periodic_damage_modifiers(self): return self.PERIODIC_DAMAGE_MODIFIERS[self.level-1]
 
-    def use(self, messanger, actor, enemy):
+    def use(self, messenger, actor, enemy):
         damage = actor.basic_damage
         damage = actor.context.modify_outcoming_damage(damage)
         enemy.context.use_damage_queue_poison([damage * modifier for modifier in self.periodic_damage_modifiers])
-        messanger.add_message('hero_ability_poison_cloud', attacker=actor, defender=enemy)
+        messenger.add_message('hero_ability_poison_cloud', attacker=actor, defender=enemy)
 
 
 class VAMPIRE_STRIKE(AbilityPrototype):
@@ -321,17 +321,17 @@ class VAMPIRE_STRIKE(AbilityPrototype):
     @property
     def damage_fraction(self): return self.DAMAGE_FRACTION[self.level-1]
 
-    def use(self, messanger, actor, enemy):
+    def use(self, messenger, actor, enemy):
         damage = actor.basic_damage * self.damage_fraction
         damage = actor.context.modify_outcoming_damage(damage)
         damage = enemy.context.modify_incoming_damage(damage)
         health = int(round(damage.total * self.heal_fraction))
         enemy.change_health(-damage.total)
         actor.change_health(health)
-        messanger.add_message('hero_ability_vampire_strike', attacker=actor, defender=enemy, damage=damage.total, health=health)
+        messenger.add_message('hero_ability_vampire_strike', attacker=actor, defender=enemy, damage=damage.total, health=health)
 
-    def on_miss(self, messanger, actor, enemy):
-        messanger.add_message('hero_ability_vampire_strike_miss', attacker=actor, defender=enemy)
+    def on_miss(self, messenger, actor, enemy):
+        messenger.add_message('hero_ability_vampire_strike_miss', attacker=actor, defender=enemy)
 
 
 class FREEZING(AbilityPrototype):
@@ -354,9 +354,9 @@ class FREEZING(AbilityPrototype):
     @property
     def initiative_modifiers(self): return self.INITIATIVE_MODIFIERS[self.level-1]
 
-    def use(self, messanger, actor, enemy):
+    def use(self, messenger, actor, enemy):
         enemy.context.use_initiative(self.initiative_modifiers)
-        messanger.add_message('hero_ability_freezing', attacker=actor, defender=enemy)
+        messenger.add_message('hero_ability_freezing', attacker=actor, defender=enemy)
 
 
 class SPEEDUP(AbilityPrototype):
@@ -379,9 +379,9 @@ class SPEEDUP(AbilityPrototype):
     @property
     def initiative_modifiers(self): return self.INITIATIVE_MODIFIERS[self.level-1]
 
-    def use(self, messanger, actor, enemy):
+    def use(self, messenger, actor, enemy):
         actor.context.use_initiative(self.initiative_modifiers)
-        messanger.add_message('hero_ability_speedup', attacker=actor, defender=enemy)
+        messenger.add_message('hero_ability_speedup', attacker=actor, defender=enemy)
 
 
 class LAST_CHANCE(AbilityPrototype):

--- a/the_tale/game/heroes/management/commands/heroes_compare_abilities.py
+++ b/the_tale/game/heroes/management/commands/heroes_compare_abilities.py
@@ -17,13 +17,13 @@ from the_tale.game.balance.power import Power, PowerDistribution
 from the_tale.game.heroes.habilities import ABILITIES, ABILITY_AVAILABILITY, ABILITY_TYPE
 
 
-class Messanger(object):
+class Messenger(object):
 
     def add_message(self, *argv, **kwargs):
         pass
 
 
-MESSANGER = Messanger()
+MESSENGER = Messenger()
 
 TEST_BATTLES_NUMBER = 40
 LEVEL = 5
@@ -39,7 +39,7 @@ def process_battle(hero_1, hero_2):
     while hero_1.health > 0 and hero_2.health > 0:
         battle.make_turn(battle.Actor(hero_1, hero_1_context),
                          battle.Actor(hero_2, hero_2_context ),
-                         MESSANGER)
+                         MESSENGER)
 
     return hero_1.health > 0
 

--- a/the_tale/game/heroes/tests/test_habilities.py
+++ b/the_tale/game/heroes/tests/test_habilities.py
@@ -22,7 +22,7 @@ from the_tale.game.balance import constants as c
 from the_tale.game.actions.fake import FakeActor
 from the_tale.game.actions.contexts.battle import Damage
 
-from the_tale.game.heroes.fake import FakeMessanger
+from the_tale.game.heroes.fake import FakeMessenger
 
 from the_tale.game.heroes.habilities import battle as battle_abilities
 from the_tale.game.heroes.habilities import modifiers as modifiers_abilities
@@ -163,7 +163,7 @@ class HabilitiesTest(TestCase):
 
     def setUp(self):
         super(HabilitiesTest, self).setUp()
-        self.messanger = FakeMessanger()
+        self.messenger = FakeMessenger()
         self.attacker = FakeActor(name='attacker')
         self.defender = FakeActor(name='defender')
 
@@ -181,37 +181,37 @@ class HabilitiesTest(TestCase):
                 self.assertTrue('on_miss' in ability_class.__dict__)
 
     def test_hit(self):
-        battle_abilities.HIT().use(self.messanger, self.attacker, self.defender)
+        battle_abilities.HIT().use(self.messenger, self.attacker, self.defender)
         self.assertTrue(self.defender.health < self.defender.max_health)
-        self.assertEqual(self.messanger.messages, ['hero_ability_hit'])
+        self.assertEqual(self.messenger.messages, ['hero_ability_hit'])
 
     def test_magic_mushroom(self):
-        battle_abilities.MAGIC_MUSHROOM().use(self.messanger, self.attacker, self.defender)
+        battle_abilities.MAGIC_MUSHROOM().use(self.messenger, self.attacker, self.defender)
         self.assertTrue(self.attacker.context.ability_magic_mushroom)
         self.assertFalse(self.defender.context.ability_magic_mushroom)
-        self.assertEqual(self.messanger.messages, ['hero_ability_magicmushroom'])
+        self.assertEqual(self.messenger.messages, ['hero_ability_magicmushroom'])
 
     def test_sidestep(self):
-        battle_abilities.SIDESTEP().use(self.messanger, self.attacker, self.defender)
+        battle_abilities.SIDESTEP().use(self.messenger, self.attacker, self.defender)
         self.assertFalse(self.attacker.context.ability_sidestep)
         self.assertTrue(self.defender.context.ability_sidestep)
-        self.assertEqual(self.messanger.messages, ['hero_ability_sidestep'])
+        self.assertEqual(self.messenger.messages, ['hero_ability_sidestep'])
 
     def test_run_up_push(self):
-        battle_abilities.RUN_UP_PUSH().use(self.messanger, self.attacker, self.defender)
+        battle_abilities.RUN_UP_PUSH().use(self.messenger, self.attacker, self.defender)
         self.assertFalse(self.attacker.context.stun_length)
         self.assertTrue(self.defender.context.stun_length)
         self.assertTrue(self.defender.health < self.defender.max_health)
-        self.assertEqual(self.messanger.messages, ['hero_ability_runuppush'])
+        self.assertEqual(self.messenger.messages, ['hero_ability_runuppush'])
 
     def test_regeneration(self):
         self.assertFalse(battle_abilities.REGENERATION().can_be_used(self.attacker))
         self.attacker.health = 1
         self.assertTrue(battle_abilities.REGENERATION().can_be_used(self.attacker))
 
-        battle_abilities.REGENERATION().use(self.messanger, self.attacker, self.defender)
+        battle_abilities.REGENERATION().use(self.messenger, self.attacker, self.defender)
         self.assertTrue(self.attacker.health > 1)
-        self.assertEqual(self.messanger.messages, ['hero_ability_regeneration'])
+        self.assertEqual(self.messenger.messages, ['hero_ability_regeneration'])
 
     def test_critical_chance(self):
         self.assertFalse(self.attacker.context.crit_chance > 0)
@@ -237,28 +237,28 @@ class HabilitiesTest(TestCase):
         self.assertTrue(self.defender.context.ninja > 0)
 
     def test_fireball(self):
-        battle_abilities.FIREBALL().use(self.messanger, self.attacker, self.defender)
+        battle_abilities.FIREBALL().use(self.messenger, self.attacker, self.defender)
         self.assertTrue(self.defender.health < self.defender.max_health)
         self.assertFalse(self.attacker.context.damage_queue_fire)
         self.assertTrue(self.defender.context.damage_queue_fire)
-        self.assertEqual(self.messanger.messages, ['hero_ability_fireball'])
+        self.assertEqual(self.messenger.messages, ['hero_ability_fireball'])
 
     def test_poison_cloud(self):
-        battle_abilities.POISON_CLOUD().use(self.messanger, self.attacker, self.defender)
+        battle_abilities.POISON_CLOUD().use(self.messenger, self.attacker, self.defender)
         self.assertEqual(self.defender.health, self.defender.max_health)
         self.assertFalse(self.attacker.context.damage_queue_poison)
         self.assertTrue(self.defender.context.damage_queue_poison)
-        self.assertEqual(self.messanger.messages, ['hero_ability_poison_cloud'])
+        self.assertEqual(self.messenger.messages, ['hero_ability_poison_cloud'])
 
     def test_vimpire_strike(self):
         self.attacker.health = 1
-        battle_abilities.VAMPIRE_STRIKE().use(self.messanger, self.attacker, self.defender)
+        battle_abilities.VAMPIRE_STRIKE().use(self.messenger, self.attacker, self.defender)
         self.assertTrue(self.defender.health < self.defender.max_health)
         self.assertTrue(self.attacker.health > 1)
-        self.assertEqual(self.messanger.messages, ['hero_ability_vampire_strike'])
+        self.assertEqual(self.messenger.messages, ['hero_ability_vampire_strike'])
 
     def test_freezing(self):
-        battle_abilities.FREEZING().use(self.messanger, self.attacker, self.defender)
+        battle_abilities.FREEZING().use(self.messenger, self.attacker, self.defender)
         self.assertEqual(self.defender.health, self.defender.max_health)
         self.assertFalse(self.attacker.context.initiative_queue)
         self.assertTrue(1 - E < self.attacker.context.initiative < 1 + E)
@@ -267,10 +267,10 @@ class HabilitiesTest(TestCase):
         self.defender.context.on_enemy_turn()
         self.assertTrue(self.defender.context.initiative < 1)
 
-        self.assertEqual(self.messanger.messages, ['hero_ability_freezing'])
+        self.assertEqual(self.messenger.messages, ['hero_ability_freezing'])
 
     def test_speedup(self):
-        battle_abilities.SPEEDUP().use(self.messanger, self.attacker, self.defender)
+        battle_abilities.SPEEDUP().use(self.messenger, self.attacker, self.defender)
         self.assertEqual(self.defender.health, self.defender.max_health)
         self.assertFalse(self.defender.context.initiative_queue)
         self.assertTrue(1 - E < self.defender.context.initiative < 1 + E)
@@ -279,7 +279,7 @@ class HabilitiesTest(TestCase):
         self.attacker.context.on_own_turn()
         self.assertTrue(self.attacker.context.initiative > 1)
 
-        self.assertEqual(self.messanger.messages, ['hero_ability_speedup'])
+        self.assertEqual(self.messenger.messages, ['hero_ability_speedup'])
 
     def test_last_chance(self):
         battle_abilities.LAST_CHANCE().update_context(self.attacker, self.defender)


### PR DESCRIPTION
Авотзамена с сохранением регистра по всему репозиторию. Тесты проходят, проблем возникнуть не должно. Большая часть вхождений это передача параметра вниз по цепочке вызовов. Замена 1 в 1, в том смысле, что до нее "messenger" в коде нигде не встречается.
