### PR TITLE
gh-1770 bag tests refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 *.pyc
 *.egg-info
 *.iml
-.idea
+venv/
+.idea/
+.cache/
 dist
 dcont
 checkers/pylint.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 Django==1.9.6
 Jinja2==2.6
 psycopg2==2.4.5
-kombu==2.3.2
+kombu==3.0.30
 postmarkup==1.2.2
 markdown==2.2.0
 xlrd==0.8.0
-mock==1.0b1
+mock==2.0.0
 pylibmc==1.2.3
 MarkupSafe==0.15
 boto==2.15.0

--- a/the_tale/accounts/logic.py
+++ b/the_tale/accounts/logic.py
@@ -10,7 +10,7 @@ from django.db import transaction
 from dext.common.utils.logic import normalize_email
 from dext.common.utils.urls import url
 
-from the_tale import amqp_environment
+from the_tale.amqp_environment import environment
 
 from the_tale.common.utils.password import generate_password
 
@@ -220,6 +220,6 @@ def initiate_transfer_money(sender_id, recipient_id, amount, comment):
                                              comment=comment)
     task = PostponedTaskPrototype.create(task)
 
-    amqp_environment.environment.workers.refrigerator.cmd_wait_task(task.id)
+    environment.workers.refrigerator.cmd_wait_task(task.id)
 
     return task

--- a/the_tale/finances/market/goods_types.py
+++ b/the_tale/finances/market/goods_types.py
@@ -3,7 +3,7 @@
 from dext.common.utils import discovering
 from dext.common.utils import jinja2
 
-from the_tale import amqp_environment
+from the_tale.amqp_environment import environment
 
 from the_tale.finances.market import exceptions
 
@@ -67,11 +67,11 @@ class BaseGoodType(object):
 
     def sync_added_item(self, account_id, item):
         if self.is_item_tradable(item):
-            amqp_environment.environment.workers.market_manager.cmd_add_item(account_id, self.create_good(item))
+            environment.workers.market_manager.cmd_add_item(account_id, self.create_good(item))
 
     def sync_removed_item(self, account_id, item):
         if self.is_item_tradable(item):
-            amqp_environment.environment.workers.market_manager.cmd_remove_item(account_id, self.create_good(item))
+            environment.workers.market_manager.cmd_remove_item(account_id, self.create_good(item))
 
     def all_goods(self, container):
         raise NotImplementedError()

--- a/the_tale/game/heroes/objects.py
+++ b/the_tale/game/heroes/objects.py
@@ -5,7 +5,7 @@ import random
 
 from dext.common.utils import cache
 
-from the_tale import amqp_environment
+from the_tale.amqp_environment import environment
 
 from the_tale.accounts import prototypes as accounts_prototypes
 from the_tale.accounts import logic as accounts_logic
@@ -680,7 +680,7 @@ class Hero(logic_accessors.LogicAccessorsMixin,
         cls.modify_ui_info_with_turn(data, for_last_turn=for_last_turn)
 
         if recache_if_required and cls.is_ui_continue_caching_required(data['ui_caching_started_at']) and GameState.is_working():
-            amqp_environment.environment.workers.supervisor.cmd_start_hero_caching(account_id)
+            environment.workers.supervisor.cmd_start_hero_caching(account_id)
 
         if patch_turns is not None and data['patch_turn'] in patch_turns:
             patch_fields = set(data['changed_fields'])


### PR DESCRIPTION
Привет!
Зарефакторил тесты с использованием моков.
Насколько это вообще приемлемо?

Зависимость `kombu==3.0.30` пришлось поднять из-за [данной](https://github.com/celery/kombu/issues/545) проблемы.

Тесты все [прошли](https://travis-ci.org/pavetok/the-tale/builds/131869296).

До

	$ ./manage.py test --nomigrations the_tale.game.heroes.tests.test_bag
	Creating test database for alias 'default'...
	.............
	----------------------------------------------------------------------
	Ran 13 tests in 3.116s

После

	$ ./manage.py test --nomigrations the_tale.game.heroes.tests.test_bag
	Creating test database for alias 'default'...
	.............
	----------------------------------------------------------------------
	Ran 13 tests in 0.602s